### PR TITLE
Delete Proctfile

### DIFF
--- a/Proctfile
+++ b/Proctfile
@@ -1,1 +1,0 @@
-web: gunicorn main:app


### PR DESCRIPTION
Incorrect file name causing deployment error
- File name must be called "Procfile" and not "Proctfile"